### PR TITLE
Auto prompt users that aren't running their timers WIP

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,6 @@ HARVEST_EMAIL=
 HARVEST_PASSWORD=
 HARVEST_LOW_HOURS=
 SLACK_ADMIN_IDS=''
-SLACK_HARVEST_MAPPER='{"xxxxxxx":"foo@v=bar.com"}'
+SLACK_HARVEST_MAPPER='{"xxxxxxx":{"email":"foo@bar.com","tt":"1234567"}}'
 
 TIMETASTIC_TOKEN=

--- a/autoprompter.coffee
+++ b/autoprompter.coffee
@@ -1,9 +1,14 @@
 Botkit = require('botkit')
 Tasks = require('./lib/harvest/tasks')
+Timetastic = require('./lib/timetastic/index')
+dotenv = require('dotenv')
+
+ENV = process.env.NODE_ENV || 'development'
+dotenv.load() if ENV == 'development'
 
 # Check for ENV's
-if not process.env.SLACK_TOKEN or not process.env.REDIS_URL or not process.env.PORT or not process.env.SLACK_ADMIN_IDS
-  console.log('Error: Specify SLACK_TOKEN, REDIS_URL, SLACK_ADMIN_IDS and port in environment')
+if not process.env.SLACK_TOKEN or not process.env.REDIS_URL or not process.env.SLACK_ADMIN_IDS
+  console.log('Error: Specify SLACK_TOKEN, REDIS_URL and SLACK_ADMIN_IDS in environment')
   process.exit(1)
 
 # check for additional Harvest ENV's
@@ -20,8 +25,6 @@ controller = Botkit.slackbot
 bot = controller.spawn(token: process.env.SLACK_TOKEN)
 
 tasks = new Tasks('')
-if tasks.in_core_hours(tasks.now_in_uk())
+if true #tasks.in_core_hours(tasks.now_in_uk())
   tt = new Timetastic()
-  bot.startConversation message, (err, convo) ->
-    return console.log 'An error occured', err if err
-    tasks.auto_prompt bot, tt, (opts) -> console.log('Done')
+  tasks.auto_prompt bot, tt, (opts) -> process.exit(1)

--- a/autoprompter.coffee
+++ b/autoprompter.coffee
@@ -1,0 +1,27 @@
+Botkit = require('botkit')
+Tasks = require('./lib/harvest/tasks')
+
+# Check for ENV's
+if not process.env.SLACK_TOKEN or not process.env.REDIS_URL or not process.env.PORT or not process.env.SLACK_ADMIN_IDS
+  console.log('Error: Specify SLACK_TOKEN, REDIS_URL, SLACK_ADMIN_IDS and port in environment')
+  process.exit(1)
+
+# check for additional Harvest ENV's
+if not process.env.HARVEST_LOW_HOURS
+  console.log('Harvest Error: Specify HARVEST_LOW_HOURS in environment')
+  process.exit(1)
+
+controller = Botkit.slackbot
+  debug: true,
+  log: true,
+#  storage: redis_storage
+
+# Chat
+bot = controller.spawn(token: process.env.SLACK_TOKEN)
+
+tasks = new Tasks('')
+if tasks.in_core_hours(tasks.now_in_uk())
+  tt = new Timetastic()
+  bot.startConversation message, (err, convo) ->
+    return console.log 'An error occured', err if err
+    tasks.auto_prompt bot, tt, (opts) -> console.log('Done')

--- a/autoprompter.coffee
+++ b/autoprompter.coffee
@@ -27,4 +27,6 @@ bot = controller.spawn(token: process.env.SLACK_TOKEN)
 tasks = new Tasks('')
 if true #tasks.in_core_hours(tasks.now_in_uk())
   tt = new Timetastic()
-  tasks.auto_prompt bot, tt, (opts) -> process.exit(1)
+  tasks.auto_prompt bot, tt, (opts) ->
+    console.log(opts)
+    process.exit(1)

--- a/autoprompter.coffee
+++ b/autoprompter.coffee
@@ -25,8 +25,6 @@ controller = Botkit.slackbot
 bot = controller.spawn(token: process.env.SLACK_TOKEN)
 
 tasks = new Tasks('')
-if true #tasks.in_core_hours(tasks.now_in_uk())
+if tasks.in_core_hours(tasks.now_in_uk())
   tt = new Timetastic()
-  tasks.auto_prompt bot, tt, (opts) ->
-    console.log(opts)
-    process.exit(1)
+  tasks.auto_prompt bot, tt

--- a/bot.coffee
+++ b/bot.coffee
@@ -101,7 +101,7 @@ controller.hears 'hv (today|last|\\d{1,2}-\\d{1,2}-\\d{4}) (.*)', 'direct_messag
   return if not permissions.admin_reply bot, message
   username = message.match[2]
   userid = username.match(/<@(.*)>/i)[1]
-  email = slack_harvest_mapper[userid]
+  email = slack_harvest_mapper[userid].email
   datestr = message.match[1]
   tasks = new Tasks(email)
 

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -202,8 +202,7 @@ module.exports = ->
       opts = running: false
       this.daily user, opts, (_task) =>
         if _task.hasOwnProperty 'not_running'
-          console.log('users timer is not running...', user, _task)
-          # Convert timetastic user id to slack user id
+          slack_user_id = this._slack_id_from_email(user.email)
           return
 
   this.prompt = (userid, bot, callback) ->
@@ -276,6 +275,7 @@ module.exports = ->
     matching_slack_user?.tt
 
   this._slack_id_from_timetastic_id = (timetastic_id) ->
+    timetastic_id = timetastic_id.toString()
     try
       slack_users = JSON.parse(process.env.SLACK_HARVEST_MAPPER)
     catch e
@@ -284,6 +284,17 @@ module.exports = ->
     matching_slack_user = _.find _.pairs(slack_users), (pair) ->
       [slack_id, details] = pair
       details.tt == timetastic_id
+    matching_slack_user?[0]
+
+  this._slack_id_from_email = (email) ->
+    try
+      slack_users = JSON.parse(process.env.SLACK_HARVEST_MAPPER)
+    catch e
+      console.log(e)
+      return 0
+    matching_slack_user = _.find _.pairs(slack_users), (pair) ->
+      [slack_id, details] = pair
+      details.email == email
     matching_slack_user?[0]
 
   this._is_user_away = (user, timetastic_user_ids) ->

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -266,7 +266,7 @@ module.exports = ->
     matching_slack_user.tt
 
   this._is_user_away = (user, timetastic_user_ids) ->
-    # timetastic_id = this._timetastic_id_from_email(user.email)
-    # timetastic_id and _.contains(timetastic_user_ids, timetastic_id)
-    null
+    timetastic_id = this._timetastic_id_from_email(user.email)
+    return (timetastic_id and _.contains(timetastic_user_ids, parseInt(timetastic_id, 10)))
+
   return

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -303,7 +303,10 @@ module.exports = ->
     timetastic_id = this._timetastic_id_from_email(user.email)
     return !!(timetastic_id and _.contains(timetastic_user_ids, parseInt(timetastic_id, 10)))
 
+  this.now_in_uk = () ->
+    moment().tz('Europe/London')
+
   this.in_core_hours = (now) ->
-    (now.hour() >= 9 && now.hour() < 12) || (now.hour() >= 14 && now.hour() < 17)
+    (now.isoWeekday() < 6) && (now.hour() >= 9 && now.hour() < 12) || (now.hour() >= 14 && now.hour() < 17)
 
   return

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -188,17 +188,22 @@ module.exports = ->
     # First get list of users that are on holiday
     tt.users_away_today (err, users_away) =>
       if err == null
-        user_ids_away = users_away.map (user) -> user.userId
+        user_ids_away = users_away.map (u) -> u.userId
         console.log('users that are on holiday today...', user_ids_away)
-        this.users (_peoples) =>
-          for _person in _peoples
-            user = _person.user
-            if user.is_active and not user.is_admin and not this._is_user_away(user, user_ids_away)
-              opts = running: false
-              this.daily user, opts, (_task) =>
-                if _task.hasOwnProperty 'not_running'
-                  console.log('users timer is not running...', user)
-                  return
+        this.users (people) =>
+          console.log(people)
+          for person in people
+            user = person.user
+            this.auto_prompt_user(user, bot, user_ids_away, callback)
+
+  this.auto_prompt_user = (user, bot, user_ids_away, callback) =>
+    console.log(user.email)
+    if user.is_active and not user.is_admin and not this._is_user_away(user, user_ids_away)
+      opts = running: false
+      this.daily user, opts, (_task) =>
+        if _task.hasOwnProperty 'not_running'
+          console.log('users timer is not running...', user, _task)
+          return
 
   this.prompt = (userid, bot, callback) ->
     bot.api.im.open { user: userid }, (err, response) ->

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -185,7 +185,7 @@ module.exports = ->
 
       callback(user, entries)
 
-  this.auto_prompt = (bot, tt, callback) =>
+  this.auto_prompt = (bot, tt) =>
     # First get list of users that are on holiday
     tt.users_away_today (err, users_away) =>
       if err == null
@@ -193,9 +193,9 @@ module.exports = ->
         this.users (people) =>
           for person in people
             user = person.user
-            this.auto_prompt_user(user, bot, user_ids_away, callback)
+            this.auto_prompt_user(user, bot, user_ids_away)
 
-  this.auto_prompt_user = (user, bot, user_ids_away, callback) =>
+  this.auto_prompt_user = (user, bot, user_ids_away) =>
     if user.is_active and not user.is_admin and not this._is_user_away(user, user_ids_away)
       opts = running: false
       this.daily user, opts, (_task) =>

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -260,13 +260,17 @@ module.exports = ->
       .replace(/-/g, '')
 
   this._timetastic_id_from_email = (email) ->
-    slack_users = JSON.parse(process.env.SLACK_HARVEST_MAPPER)
+    try
+      slack_users = JSON.parse(process.env.SLACK_HARVEST_MAPPER)
+    catch e
+      console.log(e)
+      return 0
     matching_slack_user = _.find _.values(slack_users), (user) ->
       user.email == email
-    matching_slack_user.tt
+    matching_slack_user?.tt
 
   this._is_user_away = (user, timetastic_user_ids) ->
     timetastic_id = this._timetastic_id_from_email(user.email)
-    return (timetastic_id and _.contains(timetastic_user_ids, parseInt(timetastic_id, 10)))
+    return !!(timetastic_id and _.contains(timetastic_user_ids, parseInt(timetastic_id, 10)))
 
   return

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -197,6 +197,11 @@ module.exports = ->
 
       callback(opts)
 
+  this._is_user_online = (user, bot, callback) ->
+    bot.api.users.getPresence user, (err, response) ->
+      result = !err && response.presence == 'active'
+      callback(err, result)
+
   this._is_user_on_holiday = (user) ->
     tt.away { when: 'today' }, (msg) ->
       # TODO

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -189,20 +189,21 @@ module.exports = ->
     tt.users_away_today (err, users_away) =>
       if err == null
         user_ids_away = users_away.map (u) -> u.userId
-        console.log('users that are on holiday today...', user_ids_away)
         this.users (people) =>
-          console.log(people)
           for person in people
             user = person.user
             this.auto_prompt_user(user, bot, user_ids_away, callback)
 
   this.auto_prompt_user = (user, bot, user_ids_away, callback) =>
-    console.log(user.email)
     if user.is_active and not user.is_admin and not this._is_user_away(user, user_ids_away)
       opts = running: false
       this.daily user, opts, (_task) =>
         if _task.hasOwnProperty 'not_running'
           slack_user_id = this._slack_id_from_email(user.email)
+          # while debugging only send notifications to myself
+          if slack_user_id == 'U0HLP6P8W'
+            console.log 'notifying...', slack_user_id, user.email
+            this.prompt(slack_user_id, bot, callback)
           return
 
   this.prompt = (userid, bot, callback) ->

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -201,10 +201,12 @@ module.exports = ->
       this.daily user, opts, (_task) =>
         if _task.hasOwnProperty 'not_running'
           slack_user_id = this._slack_id_from_email(user.email)
-          # while debugging only send notifications to myself
           if slack_user_id == 'U0HLP6P8W'
             console.log 'notifying...', slack_user_id, user.email
-            this.prompt(slack_user_id, bot, callback)
+            this.prompt slack_user_id, bot, (opts) ->
+              bot.api.chat.postMessage opts, (err, response) ->
+                return console.log 'An error occured', err if err
+                console.log "#{user.email} has been gently prompted."
           return
 
   this.prompt = (userid, bot, callback) ->

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -189,23 +189,25 @@ module.exports = ->
 
     # First get list of users that are on holiday
     tt.users_away_today (err, users_away) =>
-      console.log('users that are on holiday today...', users_away)
-      this.users (_peoples) =>
-        for _person in _peoples
-          user = _person.user
-          console.log('found user...', user)
+      if err == null
+        user_names_away = users_away.map (user) -> user.userName
+        console.log('users that are on holiday today...', user_names_away)
+        this.users (_peoples) =>
+          for _person in _peoples
+            user = _person.user
+            console.log('found user...', user)
 
-          if user.is_active and not user.is_admin
-            this.daily user, opts, (_task) =>
-              if _task.hasOwnProperty 'not_running'
-                console.log('users timer is not running...', user)
-                # check to make sure the user is not on holiday when their
-                # time isn't on
-                # this._is_user_is_away user, users_away, (err, _on_hols) =>
-                #   console.log(user, _on_hols)
-                  # userid = ?
-                  # this.prompt(userid, bot, callback)) unless _on_hols
-                return
+            if user.is_active and not user.is_admin and not this._is_user_away(user, user_names_away)
+              this.daily user, opts, (_task) =>
+                if _task.hasOwnProperty 'not_running'
+                  console.log('users timer is not running...', user)
+                  # check to make sure the user is not on holiday when their
+                  # time isn't on
+                  # this._is_user_is_away user, users_away, (err, _on_hols) =>
+                  #   console.log(user, _on_hols)
+                    # userid = ?
+                    # this.prompt(userid, bot, callback)) unless _on_hols
+                  return
 
   this.prompt = (userid, bot, callback) ->
     bot.api.im.open { user: userid }, (err, response) ->
@@ -265,4 +267,8 @@ module.exports = ->
     this._yesterday_as_date(date).toISOString()
       .split('T')[0]
       .replace(/-/g, '')
+
+  this._is_user_away = (user, user_names) ->
+    fullname = this._fullname(user)
+    _.contains(user_names, fullname)
   return

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -153,7 +153,15 @@ module.exports = ->
 
         if user.is_active and not user.is_admin
           this.daily user, opts, (_task) =>
-            callback(this._format_task_entry(_task))
+            if _task.hasOwnProperty 'not_running'
+              # check to make sure the user is not on holiday when their
+              # time isn't on
+              this._is_user_on_holiday user, (_on_hols) =>
+                callback(this._format_task_entry(_task)) unless _on_hols
+              return
+            else
+              callback(this._format_task_entry(_task))
+
 
   this.daily = (user, opts, callback) =>
     harvest_opts = of_user: user.id
@@ -188,6 +196,10 @@ module.exports = ->
         username: 'HarvestBot'
 
       callback(opts)
+
+  this._is_user_on_holiday = (user) ->
+    tt.away { when: 'today' }, (msg) ->
+      # TODO
 
   this._fullname = (user) ->
     "#{user.first_name} #{user.last_name}"

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -1,5 +1,6 @@
 Harvest = require('harvest')
 _ = require('underscore')
+moment = require('moment-timezone')
 
 module.exports = ->
   this.harvest = new Harvest(
@@ -301,5 +302,8 @@ module.exports = ->
   this._is_user_away = (user, timetastic_user_ids) ->
     timetastic_id = this._timetastic_id_from_email(user.email)
     return !!(timetastic_id and _.contains(timetastic_user_ids, parseInt(timetastic_id, 10)))
+
+  this.in_core_hours = (now) ->
+    (now.hour() >= 9 && now.hour() < 12) || (now.hour() >= 14 && now.hour() < 17)
 
   return

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -185,28 +185,19 @@ module.exports = ->
       callback(user, entries)
 
   this.auto_prompt = (bot, tt, callback) =>
-    opts = running: false
-
     # First get list of users that are on holiday
     tt.users_away_today (err, users_away) =>
       if err == null
-        user_names_away = users_away.map (user) -> user.userName
-        console.log('users that are on holiday today...', user_names_away)
+        user_ids_away = users_away.map (user) -> user.userId
+        console.log('users that are on holiday today...', user_ids_away)
         this.users (_peoples) =>
           for _person in _peoples
             user = _person.user
-            console.log('found user...', user)
-
-            if user.is_active and not user.is_admin and not this._is_user_away(user, user_names_away)
+            if user.is_active and not user.is_admin and not this._is_user_away(user, user_ids_away)
+              opts = running: false
               this.daily user, opts, (_task) =>
                 if _task.hasOwnProperty 'not_running'
                   console.log('users timer is not running...', user)
-                  # check to make sure the user is not on holiday when their
-                  # time isn't on
-                  # this._is_user_is_away user, users_away, (err, _on_hols) =>
-                  #   console.log(user, _on_hols)
-                    # userid = ?
-                    # this.prompt(userid, bot, callback)) unless _on_hols
                   return
 
   this.prompt = (userid, bot, callback) ->
@@ -268,7 +259,14 @@ module.exports = ->
       .split('T')[0]
       .replace(/-/g, '')
 
-  this._is_user_away = (user, user_names) ->
-    fullname = this._fullname(user)
-    _.contains(user_names, fullname)
+  this._timetastic_id_from_email = (email) ->
+    slack_users = JSON.parse(process.env.SLACK_HARVEST_MAPPER)
+    matching_slack_user = _.find _.values(slack_users), (user) ->
+      user.email == email
+    matching_slack_user.tt
+
+  this._is_user_away = (user, timetastic_user_ids) ->
+    # timetastic_id = this._timetastic_id_from_email(user.email)
+    # timetastic_id and _.contains(timetastic_user_ids, timetastic_id)
+    null
   return

--- a/lib/harvest/tasks.coffee
+++ b/lib/harvest/tasks.coffee
@@ -203,6 +203,7 @@ module.exports = ->
       this.daily user, opts, (_task) =>
         if _task.hasOwnProperty 'not_running'
           console.log('users timer is not running...', user, _task)
+          # Convert timetastic user id to slack user id
           return
 
   this.prompt = (userid, bot, callback) ->
@@ -273,6 +274,17 @@ module.exports = ->
     matching_slack_user = _.find _.values(slack_users), (user) ->
       user.email == email
     matching_slack_user?.tt
+
+  this._slack_id_from_timetastic_id = (timetastic_id) ->
+    try
+      slack_users = JSON.parse(process.env.SLACK_HARVEST_MAPPER)
+    catch e
+      console.log(e)
+      return 0
+    matching_slack_user = _.find _.pairs(slack_users), (pair) ->
+      [slack_id, details] = pair
+      details.tt == timetastic_id
+    matching_slack_user?[0]
 
   this._is_user_away = (user, timetastic_user_ids) ->
     timetastic_id = this._timetastic_id_from_email(user.email)

--- a/lib/timetastic/index.coffee
+++ b/lib/timetastic/index.coffee
@@ -14,8 +14,10 @@ class Timetastic
     today = new Date()
     date_string = @date_plus_as_string(today, amt)
 
-    @find_holidays_on date_string, (err, users) ->
+    @find_holidays_on date_string, (err, users) =>
       if !err
+        users = users.map (user) => @user_output_string(user, today)
+        console.log(users)
         attachments = []
         status = ":party: Everyone is here #{cmd}! :party:"
 
@@ -49,8 +51,7 @@ class Timetastic
 
     @request request_options, (err, response, body) =>
       if !err and response.statusCode is 200
-        users = body.holidays.map (user) => @user_output_string(user, today)
-        callback(err, users)
+        callback(err, body.holidays)
       else
         callback(err, null)
     return

--- a/lib/timetastic/index.coffee
+++ b/lib/timetastic/index.coffee
@@ -5,7 +5,7 @@ class Timetastic
 
   users_away_today: (callback) ->
     date_string = @date_plus_as_string(new Date(), 0)
-    find_holidays_on(date_string, callback)
+    @find_holidays_on(date_string, callback)
 
   away: (opt, callback) ->
     cmd = opt.when or 'today'

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "test": "mocha --require coffee-script/register --compilers coffee:coffee-script --no-colors"
   },
   "dependencies": {
-    "coffee-script": "1.10",
     "botkit": "0.0.5",
-    "redis": "~2.4",
+    "coffee-script": "1.10",
     "googleapis": "~2.1",
     "harvest": "~0.1",
+    "moment": "^2.12.0",
+    "moment-timezone": "^0.5.3",
+    "redis": "~2.4",
     "underscore": "~1.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "scripts": {
     "start": "coffee bot.coffee",
     "debug": "coffee --nodejs --debug bot.coffee",
-    "test": "mocha --require coffee-script/register --compilers coffee:coffee-script --no-colors"
+    "test": "mocha --require coffee-script/register --compilers coffee:coffee-script --no-colors",
+    "autoprompt": "coffee autoprompter.coffee"
   },
   "dependencies": {
     "botkit": "0.0.5",
     "coffee-script": "1.10",
+    "dotenv": "^2.0.0",
     "googleapis": "~2.1",
     "harvest": "~0.1",
     "moment": "^2.12.0",

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -161,16 +161,33 @@ describe 'Tasks', ->
 
   describe '#_is_user_away', ->
     json = '{"U0HLJHWJW":{"email":"alice@example.com","tt":"234567"},"U0HLGQMBK":{"email":"bob@example.com","tt":"123456"}}'
-    process.env.SLACK_HARVEST_MAPPER = json
-    user =
-      id: 456789
-      email: 'bob@example.com'
 
     it 'should return true if the user is on the holiday list', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      user =
+        id: 456789
+        email: 'bob@example.com'
       expect(task._is_user_away user, [123456, 234567]).to.be.true
 
     it 'should return false if the user is unknown', () ->
-      expect(task._is_user_away user, [123456, 234567]).to.be.true
+      process.env.SLACK_HARVEST_MAPPER = json
+      user =
+        id: 456789
+        email: 'eric@example.com'
+      expect(task._is_user_away user, [123456, 234567]).to.be.false
 
     it 'should return false if the user is NOT on the holiday list', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      user =
+        id: 456789
+        email: 'bob@example.com'
       expect(task._is_user_away user, [345678, 456789]).to.be.false
+
+    describe 'when the SLACK_HARVEST_MAPPER env var is invalid', () ->
+      process.env.SLACK_HARVEST_MAPPER = '(*&^(*'
+
+      it 'should return false', () ->
+        user =
+          id: 456789
+          email: 'bob@example.com'
+        expect(task._is_user_away user, [345678, 456789]).to.be.false

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -191,3 +191,14 @@ describe 'Tasks', ->
           id: 456789
           email: 'bob@example.com'
         expect(task._is_user_away user, [345678, 456789]).to.be.false
+
+  describe '#_slack_id_from_timetastic_id', ->
+    json = '{"U0HLJHWJW":{"email":"alice@example.com","tt":"234567"},"U0HLGQMBK":{"email":"bob@example.com","tt":"123456"}}'
+
+    it 'should return harvest id given a valid timetastic_id', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      expect(task._slack_id_from_timetastic_id '234567').to.eql('U0HLJHWJW')
+
+    it 'should return undefined given a missing timetastic_id', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      expect(task._slack_id_from_timetastic_id '999999').to.be.undefined

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -160,12 +160,16 @@ describe 'Tasks', ->
         done()
 
   describe '#_is_user_away', ->
+    json = '{"U0HLJHWJW":{"email":"alice@example.com","tt":"234567"},"U0HLGQMBK":{"email":"bob@example.com","tt":"123456"}'
     user =
-      first_name: 'John'
-      last_name: 'Doe'
+      id: 456789
+      email: 'bob@example.com'
 
     it 'should return true if the user is on the holiday list', () ->
-      expect(task._is_user_away user, ['Bob Roberts', 'John Doe', 'Alice Roberts']).to.be.true
+      expect(task._is_user_away user, [123456, 234567]).to.be.true
+
+    it 'should return false if the user is unknown', () ->
+      expect(task._is_user_away user, [123456, 234567]).to.be.true
 
     it 'should return false if the user is NOT on the holiday list', () ->
-      expect(task._is_user_away user, ['Bob Roberts', 'Alice Roberts']).to.be.false
+      expect(task._is_user_away user, [345678, 456789]).to.be.false

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -231,20 +231,26 @@ describe 'Tasks', ->
       expect(task._timetastic_id_from_email 'jim@example.com').to.be.undefined
 
   describe '#in_core_hours', ->
-
     it 'should return true during the morning', () ->
-      now = moment({ hour: 10, minute: 10 })
+      now = moment({ year: 2016, month: 3, day: 15, hour: 10, minute: 10 })
       expect(task.in_core_hours(now)).to.eql true
 
     it 'should return true during the afternoon', () ->
-      now = moment({ hour: 15, minute: 10 })
+      now = moment({ year: 2016, month: 3, day: 15, hour: 15, minute: 10 })
       expect(task.in_core_hours(now)).to.eql true
 
     it 'should return false during lunch', () ->
-      now = moment({ hour: 12, minute: 10 })
+      now = moment({ year: 2016, month: 3, day: 15, hour: 12, minute: 10 })
       expect(task.in_core_hours(now)).to.eql false
 
     it 'should return false after five', () ->
-      now = moment({ hour: 17, minute: 10 })
+      now = moment({ year: 2016, month: 3, day: 15, hour: 17, minute: 10 })
       expect(task.in_core_hours(now)).to.eql false
 
+    it 'should return false on Saturday', () ->
+      now = moment({ year: 2016, month: 3, day: 9, hour: 10, minute: 10 })
+      expect(task.in_core_hours(now)).to.eql false
+
+    it 'should return false on Sunday', () ->
+      now = moment({ year: 2016, month: 3, day: 10, hour: 10, minute: 10 })
+      expect(task.in_core_hours(now)).to.eql false

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -202,3 +202,14 @@ describe 'Tasks', ->
     it 'should return undefined given a missing timetastic_id', () ->
       process.env.SLACK_HARVEST_MAPPER = json
       expect(task._slack_id_from_timetastic_id '999999').to.be.undefined
+
+  describe '#_timetastic_id_from_email', ->
+    json = '{"U0HLJHWJW":{"email":"alice@example.com","tt":"234567"},"U0HLGQMBK":{"email":"bob@example.com","tt":"123456"}}'
+
+    it 'should return timetastic id given a valid email', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      expect(task._timetastic_id_from_email 'bob@example.com').to.eql('123456')
+
+    it 'should return undefined given a missing email', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      expect(task._timetastic_id_from_email 'jim@example.com').to.be.undefined

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -131,3 +131,17 @@ describe 'Tasks', ->
       task.daily(user, opts, callback)
 
       expect(callback.called).to.be.true
+
+  describe '#_is_user_online', ->
+    it 'should return true if the user is active in Slack', (done) ->
+      bot =
+        api:
+          users:
+            getPresence: (ops, callback) ->
+              callback(null, { presence: 'active' })
+      user =
+        first_name: 'John'
+        last_name: 'Doe'
+      task._is_user_online user, bot, (err, result) ->
+        expect(result).to.be.true
+        done()

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -145,3 +145,16 @@ describe 'Tasks', ->
       task._is_user_online user, bot, (err, result) ->
         expect(result).to.be.true
         done()
+
+    it 'should return false if the user is inactive in Slack', (done) ->
+      bot =
+        api:
+          users:
+            getPresence: (ops, callback) ->
+              callback(null, { presence: 'inactive' })
+      user =
+        first_name: 'John'
+        last_name: 'Doe'
+      task._is_user_online user, bot, (err, result) ->
+        expect(result).to.be.false
+        done()

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -1,6 +1,7 @@
 chai = require "chai"
 sinon = require "sinon"
 sinonChai = require "sinon-chai"
+moment = require "moment-timezone"
 expect = chai.expect
 chai.use sinonChai
 
@@ -228,3 +229,22 @@ describe 'Tasks', ->
     it 'should return undefined given a missing email', () ->
       process.env.SLACK_HARVEST_MAPPER = json
       expect(task._timetastic_id_from_email 'jim@example.com').to.be.undefined
+
+  describe '#in_core_hours', ->
+
+    it 'should return true during the morning', () ->
+      now = moment({ hour: 10, minute: 10 })
+      expect(task.in_core_hours(now)).to.eql true
+
+    it 'should return true during the afternoon', () ->
+      now = moment({ hour: 15, minute: 10 })
+      expect(task.in_core_hours(now)).to.eql true
+
+    it 'should return false during lunch', () ->
+      now = moment({ hour: 12, minute: 10 })
+      expect(task.in_core_hours(now)).to.eql false
+
+    it 'should return false after five', () ->
+      now = moment({ hour: 17, minute: 10 })
+      expect(task.in_core_hours(now)).to.eql false
+

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -9,10 +9,10 @@ process.env.HARVEST_SUBDOMAIN = 'kyan'
 process.env.HARVEST_EMAIL = 'a@b.com'
 process.env.HARVEST_PASSWORD = 'password'
 
-tasks = require '../lib/harvest/tasks'
+Tasks = require '../lib/harvest/tasks'
 
 describe 'Tasks', ->
-  task = new tasks()
+  task = new Tasks()
 
   describe '#_fullname()', ->
     it 'should return the fullname of the user', ->
@@ -158,3 +158,14 @@ describe 'Tasks', ->
       task._is_user_online user, bot, (err, result) ->
         expect(result).to.be.false
         done()
+
+  describe '#_is_user_away', ->
+    user =
+      first_name: 'John'
+      last_name: 'Doe'
+
+    it 'should return true if the user is on the holiday list', () ->
+      expect(task._is_user_away user, ['Bob Roberts', 'John Doe', 'Alice Roberts']).to.be.true
+
+    it 'should return false if the user is NOT on the holiday list', () ->
+      expect(task._is_user_away user, ['Bob Roberts', 'Alice Roberts']).to.be.false

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -199,9 +199,24 @@ describe 'Tasks', ->
       process.env.SLACK_HARVEST_MAPPER = json
       expect(task._slack_id_from_timetastic_id '234567').to.eql('U0HLJHWJW')
 
+    it 'should return harvest id given a valid timetastic_id as an integer', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      expect(task._slack_id_from_timetastic_id 234567).to.eql('U0HLJHWJW')
+
     it 'should return undefined given a missing timetastic_id', () ->
       process.env.SLACK_HARVEST_MAPPER = json
       expect(task._slack_id_from_timetastic_id '999999').to.be.undefined
+
+  describe '#_slack_id_from_email', ->
+    json = '{"U0HLJHWJW":{"email":"alice@example.com","tt":"234567"},"U0HLGQMBK":{"email":"bob@example.com","tt":"123456"}}'
+
+    it 'should return slack id given a valid email', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      expect(task._slack_id_from_email 'bob@example.com').to.eql('U0HLGQMBK')
+
+    it 'should return undefined given a missing email', () ->
+      process.env.SLACK_HARVEST_MAPPER = json
+      expect(task._slack_id_from_email 'jim@example.com').to.be.undefined
 
   describe '#_timetastic_id_from_email', ->
     json = '{"U0HLJHWJW":{"email":"alice@example.com","tt":"234567"},"U0HLGQMBK":{"email":"bob@example.com","tt":"123456"}}'

--- a/test/harvest_spec.coffee
+++ b/test/harvest_spec.coffee
@@ -160,7 +160,8 @@ describe 'Tasks', ->
         done()
 
   describe '#_is_user_away', ->
-    json = '{"U0HLJHWJW":{"email":"alice@example.com","tt":"234567"},"U0HLGQMBK":{"email":"bob@example.com","tt":"123456"}'
+    json = '{"U0HLJHWJW":{"email":"alice@example.com","tt":"234567"},"U0HLGQMBK":{"email":"bob@example.com","tt":"123456"}}'
+    process.env.SLACK_HARVEST_MAPPER = json
     user =
       id: 456789
       email: 'bob@example.com'

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--compilers coffee:coffee-script/register

--- a/test/timetastic_spec.coffee
+++ b/test/timetastic_spec.coffee
@@ -86,3 +86,17 @@ describe 'Timetastic', ->
         startDate: '2016-01-25T00:00:00'
         endDate: '2016-02-05T00:00:00'
       expect(tt.user_output_string(user, today)).to.equal('*Jon Doe* _Holiday, 8 days left_')
+
+  describe '#days_between()', ->
+    it 'should return the days between', ->
+      d1 = new Date('Sun, 15 Oct 2014 10:13:00 GMT')
+      d2 = new Date('Wed, 19 Oct 2014 10:13:00 GMT')
+      expect(tt.days_between(d1,d2)).to.equal(4)
+
+      d1 = new Date('2016,5,10')
+      d2 = new Date('2016,5,16')
+      expect(tt.days_between(d1,d2)).to.equal(6)
+
+      d1 = new Date('2016,5,16')
+      d2 = new Date('2016,5,16')
+      expect(tt.days_between(d1,d2)).to.equal(0)


### PR DESCRIPTION
The idea here is to automate the existing prompt method that allows admins to manually prompt specific users that aren't running a Harvest timer.

The solution implemented checks for users on holiday in Timetastic and then loops over all the active, non-admin users fetching the status from Harvest. For those that are not on holiday and aren't running a timer a prompt is automatically sent.

There is a separate script to invoke the auto_prompt method, `autoprompter.coffee` that can be invoked with `npm run autoprompt`. To run it in development just run `coffee autoprompter.coffee` (assuming you've installed coffee-script globally). The plan here is to use the Heroku Scheduler to run the process every 10 minutes or hour (depending on how strict we want to be).

There is some logic in `autoprompter.coffee` to only send notifications during core working hours, this is hard-coded to 9:00-12:00 and 14:00-17:00 and assumes everybody is working in UK time for now.

There are several areas that could be improved:

- [ ] Take account of how long a user has had their timer stopped, so that if it's only for a few minutes (or seconds) whilst they are between tasks don't pester them.
- [ ] Avoid repeated calls to the same user if they don't start their timer for a longer period.
- [ ] Cater for people that are not in UK time zone. We could extend the data structure that we store for user id mappings to include an optional time zone field.
- [ ]  Remove the debug code including the check that prevents the script pestering users other than me while testing.